### PR TITLE
Fix work on pre-ES2015 and simplify code

### DIFF
--- a/ulog.js
+++ b/ulog.js
@@ -36,8 +36,8 @@ var LVL = {ERROR:1, WARN:2, INFO:3, LOG:4, DEBUG:5, TRACE:6},
 		mods = {}, dbgMods = [], skipMods = []
 
 function create(n,r) {
-	eval("r = {'" + n + "': function() {var a = [].slice.call(arguments), m = a.length > 1 && names[a[0]] ? a.shift() : 'debug'; for (var i=0; i<log.formats.length; i++) log.formats[i](mods[n],m,a); return mods[n][m].apply(mods[n], a)}}[n]")
-	return r.name ? r : Object.defineProperty(r, 'name', {get:function(){return n}})
+	r = {};
+	return Object.defineProperty(r, 'name', {get:function(){return n}})
 }
 		
 function extend(o,p,l) {


### PR DESCRIPTION
In android lollipop emulator I found the same error (*Cannot redefine property: name*) as in #24. So I decided to try to fix it.

The first thing I tried to do was abandon eval to be able to debug. After a while, I got a minimal example leading to an error on my device:

```
var fn = function() {};
fn.name = 'val';
```
» Cannot assign to read only property 'name' of function ()

The [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) says

» Note that in non-standard, pre-ES2015 implementations the configurable attribute was false as well.

Indeed, I have `Object {value: "", writable: false, enumerable: false, configurable: false}`

That's when I decided not to use an anonymous function and directly set value of object:

```
function create(n,r) {
  r = {};
  
  var a = [].slice.call(arguments), m = a.length > 1 && names[a[0]] ? a.shift() : 'debug';
  for (var i=0; i<log.formats.length; i++)
    log.formats[i](mods[n],m,a);

  Object.defineProperty(r, n, {value: mods[n] ? mods[n][m].apply(mods[n], a) : {}, writable: true});
  r = r[n];

  return r.name ? r : Object.defineProperty(r, 'name', {get:function(){return n}, enumerable: true, configurable: false})
}
```

But since `mods[n]` value inside `create()` is always undefined (it is then filled in `extend()`), all this code is not needed and is not executed. It can be simplify to

```
function create(n,r) {
	r = {};
	return Object.defineProperty(r, 'name', {get:function(){return n}})
}
```

I may have made a mistake somewhere or all this code was written by you for use in the future, so purpose of this PR is rather to show in which direction to go to correct error on Android KitKat and all pre-ES2015 devices. Or at least to get rid of eval(), because eval is a nightmare.