### PR TITLE
Fix whitespace and add braces to one-line for loop

### DIFF
--- a/core/grab.js
+++ b/core/grab.js
@@ -1,12 +1,13 @@
 module.exports = function(ulog, name, result) {
-	ulog.mods.reduce(function(r,item){
+	ulog.mods.reduce(function(r,item) {
 		if (Array.isArray(r) && (name in item)) {
 			r.push(item[name])
 		} else {
-			for (var o in item[name])
-        r[o] = item[name][o]
+			for (var o in item[name]) {
+				r[o] = item[name][o]
+			}
 		}
 		return r
-  }, result)
-  return result
+	}, result)
+	return result
 }


### PR DESCRIPTION
1) Prior to this change, viewing mixed tabs and spaces on GitHub caused the body of the for loop to have less visually preceding whitespace than the loop description itself.
2) I've included for loop braces to prevent any ambiguity for the reader.
3) Added a space between the reduce callback function and its opening brace to mirror the whitespace used on the first line.