### PR TITLE
Configurable polling timeout and bugfix in watch.browser 

### DIFF
--- a/mods/config/index.js
+++ b/mods/config/index.js
@@ -7,12 +7,18 @@ var notify = require('./notify')
 var watch = require('./watch')
 var config = module.exports = {
   use: [
-    require('../settings'),
+    require('../settings')
   ],
 
   settings: {
     config: {
       config: 'log_config'
+    },
+    pollTime: {
+      config: 'poll_time',
+      prop: {
+        default: 350
+      }
     }
   },
 
@@ -42,5 +48,9 @@ var config = module.exports = {
 
   set: function(name) {
     if (name === 'log_config') config.update(this)
+  },
+
+  after: function () {
+    config.update(this);
   }
 }

--- a/mods/config/watch.browser.js
+++ b/mods/config/watch.browser.js
@@ -1,19 +1,59 @@
-var read = require('./read')
-var update = require('./update')
-var notify = require('./notify')
+var read = require('./read');
+var update = require('./update');
+var notify = require('./notify');
+
+var ulogs = new Set();
+
+var minPollTime = 350;
+var maxPollTime = 5000;
+var defaultPollTime = 350;
 
 module.exports = function(ulog) {
-  // storage events unfortunately only fire on events triggered by other windows...
-  // so we need to poll here...
-  setInterval(function(){
-    if (ulog.config) {
-      var cfg = read(ulog)
-      setTimeout(function(){
-        var changed = update(ulog.config, cfg)
-        if (changed.length) setTimeout(function(){
-          notify(ulog, changed)
-        }, 0)
-      }, 0)
+  var delay = defaultPollTime;
+  var intervalId = null;
+
+  if(!ulogs.has(ulog)) {
+    // storage events unfortunately only fire on events triggered by other windows...
+    // so we need to poll here...
+    startPolling();
+
+    ulogs.add(ulog);
+  }
+
+  return stopPolling;
+
+  function stopPolling() {
+    if(intervalId !== null) {
+      clearInterval(intervalId);
+
+      intervalId = null;
     }
-  }, 350)
-}
+  }
+  function startPolling(){
+    intervalId = setInterval(pollStorageConfig, delay)
+  }
+
+  function pollStorageConfig(){
+    if (ulog.config) {
+      var cfg = read(ulog);
+
+      var changed = update(ulog.config, cfg);
+
+      if (changed.length) {
+        notify(ulog, changed)
+      }
+
+      var newDelay = parseInt(ulog.get('poll_time'), 10) || defaultPollTime;
+      if(newDelay < minPollTime) {
+        newDelay = minPollTime;
+      } else if(newDelay > maxPollTime) {
+        newDelay = maxPollTime;
+      }
+      if (newDelay !== delay) {
+        delay = newDelay;
+        stopPolling();
+        startPolling();
+      }
+    }
+  }
+};


### PR DESCRIPTION
Closes #52 and fix #55 and maybe #56
[FEATURE] add poll_time config option to change interval timeout
[FEATURE] add bounds for poll_time to prevent unhandy config values
[BUGFIX] add a Set to prevent starting multiple interval on already watched ulog instances
[BUGFIX] add ulog after hook to update config immediately after loading all mods